### PR TITLE
Convert AbstractHandle type into Python backend.

### DIFF
--- a/myia_backend_python/myia_backend_python/python.py
+++ b/myia_backend_python/myia_backend_python/python.py
@@ -13,7 +13,7 @@ from myia.compile.transform import convert_grad, get_prim_graph
 from myia.debug.label import NodeLabeler
 from myia.graph_utils import toposort
 from myia.ir import Graph, manage
-from myia.lib import ANYTHING, AbstractArray, AbstractTuple
+from myia.lib import ANYTHING, AbstractArray, AbstractTuple, AbstractHandle
 from myia.operations import Primitive, primitives as P
 from myia.xtype import type_to_np_dtype
 
@@ -443,6 +443,9 @@ class PythonConstantConverter(_PythonConverter):
     def convert_type(self, v, t):
         myia_type = t.element.xtype()
         # Return type name as a string.
+        if myia_type is None:
+            if isinstance(v, AbstractHandle):
+                return "HandleInstance"
         return f"'{type_to_np_dtype(myia_type)}'"
 
     def convert_handle(self, v, t):


### PR DESCRIPTION
Hi @abergeron I open this PR to fix Python backend issues related to handles. Current commit seems to fix test `pytest -xvvs tests/test_universal.py::test_increment_loop[python]`. Output (with Python backend option `debug=True`):

PS: Current commit converts abstract handle type to Python `HandleInstance` type. However, it seems the conversion is unused in this test (see `AbstractHandle_H_Int_64 = HandleInstance` in main function).

```
(myiagpu) notoraptor@notoraptor-linux:~/mila/dev/git/myia$ pytest -xvvs tests/test_universal.py::test_increment_loop[python]
=========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.7.9, pytest-6.1.2, py-1.9.0, pluggy-0.13.1 -- /home/notoraptor/anaconda3/envs/myiagpu/bin/python
cachedir: .pytest_cache
rootdir: /media/win/Users/notoraptor/mila/dev/git/myia, configfile: pytest.ini
plugins: cov-2.10.1, xdist-2.1.0, forked-1.3.0
collected 1 item                                                                                                                                                                                          

tests/test_universal.py::test_increment_loop[python] 
import math
import numpy as np
from myia.utils import RandomStateWrapper
from myia.lib import TaggedValue
from myia.utils.universe import HandleInstance
import myia_backend_python.implementations as IMPL
def _9_while_header_plus(_phi_i, _U_v2, _llift_4):
    _scalar_gt = _phi_i > 0
    _switch = _12_while_body_plus if _scalar_gt else _10_while_after_plus
    return _switch(_U_v2, _llift_4, _phi_i)

def _12_while_body_plus(_U_v3, _llift_4_v2, _llift_phi_i):
    _universe_getitem = _U_v3.get(_llift_4_v2)
    _universe_getitem_v2 = _U_v3.get(_universe_getitem)
    _scalar_add = _universe_getitem_v2 + 1
    _new_universe_v3 = _U_v3.set(_universe_getitem, _scalar_add)
    _new_universe_v3.commit()
    _universe_setitem_v5 = _new_universe_v3
    _scalar_sub = _llift_phi_i - 1
    return _9_while_header_plus(_scalar_sub, _universe_setitem_v5, _llift_4_v2)

def _10_while_after_plus(_U_v4, _llift_4_v3, _llift_phi_i_v2):
    _universe_getitem_v5 = _U_v4.get(_llift_4_v3)
    _universe_getitem_v6 = _U_v4.get(_universe_getitem_v5)
    return (_U_v4, _universe_getitem_v6,)

def main(_x, _y, _U):
    # Constants
    _AbstractScalar_Int_64 = 'int64'
    _AbstractHandle_H_Int_64 = HandleInstance
    
    _handle = HandleInstance(None, None)
    _make_handle = (_U, _handle)
    _tuple_getitem = _make_handle[1]
    _tuple_getitem_v2 = _make_handle[0]
    _new_universe = _tuple_getitem_v2.set(_tuple_getitem, _x)
    _new_universe.commit()
    _universe_setitem = _new_universe
    _handle_v2 = HandleInstance(None, None)
    _make_handle_v2 = (_universe_setitem, _handle_v2)
    _tuple_getitem_v3 = _make_handle_v2[1]
    _tuple_getitem_v4 = _make_handle_v2[0]
    _new_universe_v2 = _tuple_getitem_v4.set(_tuple_getitem_v3, _tuple_getitem)
    _new_universe_v2.commit()
    _universe_setitem_v2 = _new_universe_v2
    return _9_while_header_plus(_y, _universe_setitem_v2, _tuple_getitem_v3)

PASSED

============================================================================================ warnings summary =============================================================================================
tests/test_universal.py::test_increment_loop[python]
tests/test_universal.py::test_increment_loop[python]
  /home/notoraptor/anaconda3/envs/myiagpu/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject
    return f(*args, **kwds)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
====================================================================================== 1 passed, 2 warnings in 1.28s ======================================================================================
```